### PR TITLE
Add support for multiple agreements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # Harbourmaster Newsletter integration
+
+This modules provides integration wuth Harbourmaster Newsletter service.
+
+### Configuration
+
+After module is enabled following things has to be configured:
+1. In administration page: `/admin/config/hm_newsletter/newsletter`, "Client ID" has to be set. Also displayed agreements should be checked are they in compliance to site.
+2. After that Newsletter block should be added to wanted page. That can be done on `` page with proper configuration of block.
+3. When block is placed it has to be configured and one of important configurations is "Newsletters" text. It has to be in following format:
+```
+<Client ID>_<Group ID>|<Text displayed next to checkbox>
+```
+for example:
+```
+100001_10|Weekly newsletter with latest published articles
+100001_11|Monthly newsletter with most read articles
+```
+4. After that newsletter form should functioning properly.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This modules provides integration wuth Harbourmaster Newsletter service.
 
 After module is enabled following things has to be configured:
 1. In administration page: `/admin/config/hm_newsletter/newsletter`, "Client ID" has to be set. Also displayed agreements should be checked are they in compliance to site.
+By default following agreements will be set: `datenschutzeinwilligung|anspracheerlaubnis` - and if something different is required for site, then it should be filled accordingly.
 2. After that Newsletter block should be added to wanted page. That can be done on `` page with proper configuration of block.
 3. When block is placed it has to be configured and one of important configurations is "Newsletters" text. It has to be in following format:
 ```

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "burdamagazinorg/hm_newsletter",
   "type": "drupal-module",
   "description": "Harbourmaster Newsletter integration",
-  "license": "GPL-2.0+",
+  "license": "GPL-2.0-or-later",
   "minimum-stability": "dev",
   "require-dev": {
     "burdamagazinorg/thunder-dev-tools": "dev-master"

--- a/config/install/hm_newsletter.settings.yml
+++ b/config/install/hm_newsletter.settings.yml
@@ -1,3 +1,6 @@
 hm_environment: 'production'
 hm_client_id: ''
 hm_imprint_text: ''
+hm_displayed_agreements:
+  - 'datenschutzeinwilligung'
+  - 'anspracheerlaubnis'

--- a/config/schema/hm_newsletter.schema.yml
+++ b/config/schema/hm_newsletter.schema.yml
@@ -1,0 +1,19 @@
+hm_newsletter.settings:
+  type: config_object
+  label: 'Harbourmaster newsletter settings'
+  mapping:
+    hm_environment:
+      type: string
+      label: 'Environment'
+    hm_client_id:
+      type: string
+      label: 'Client ID'
+    hm_imprint_text:
+      type: string
+      label: 'Imprint text'
+    hm_displayed_agreements:
+      type: sequence
+      label: 'List of displayed agreements'
+      sequence:
+        type: string
+        label: 'Agreement index'

--- a/css/hm_newsletter.css
+++ b/css/hm_newsletter.css
@@ -124,7 +124,6 @@
   color: #a94442;
 }
 
-.promo_permission_text--hidden,
 .hm_newsletter__error,
 .hm_newsletter__success,
 .hm_newsletter__promo_permission_more,
@@ -166,7 +165,6 @@
 }
 
 .hm_newsletter .form-horizontal,
-.hm_newsletter.state-privacy .hm_newsletter__privacy,
 .hm_newsletter.state-success .hm_newsletter__success {
   display: block;
 }

--- a/hm_newsletter.install
+++ b/hm_newsletter.install
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @file
+ * Update hooks for for HM Newsletter module.
+ */
+
+/**
+ * Add new configuration options.
+ */
+function hm_newsletter_update_8001() {
+  // Set configuration to display "datenschutzeinwilligung" and "privacy", since
+  // that was previous behaviour.
+  \Drupal::configFactory()
+    ->getEditable('hm_newsletter.settings')
+    ->set('hm_displayed_agreements', ['datenschutzeinwilligung', 'privacy'])
+    ->save();
+}

--- a/hm_newsletter.libraries.yml
+++ b/hm_newsletter.libraries.yml
@@ -4,6 +4,7 @@ base:
     'js/thsixty.load.js': {}
     'js/hm_newsletter.js': {}
   dependencies:
+    - core/drupal
     - core/drupalSettings
     - core/jquery.once
   css:

--- a/js/hm_newsletter.js
+++ b/js/hm_newsletter.js
@@ -407,7 +407,7 @@ Number.prototype.pad = function (size) {
    */
   Drupal.behaviors.hmNewsletter = {
     attach: function (context, settings) {
-      if ($('.hm_newsletter', context).hasClass('initialized') || $(context).is('.hm_newsletter.initialized')) {
+      if ($('.hm_newsletter', context).length === 0 || $('.hm_newsletter', context).hasClass('initialized') || $(context).is('.hm_newsletter.initialized')) {
         return;
       }
 

--- a/js/thsixty.load.js
+++ b/js/thsixty.load.js
@@ -5,6 +5,11 @@
 (function ($, window, document) {
   Drupal.behaviors.thsixty = {
     attach: function (context) {
+      // Check if "thsixtyQ" is already loaded.
+      if (window.thsixtyQ) {
+        return;
+      }
+
       var config = {
         env: drupalSettings.hm_newsletter.env,
         version: 'v1'

--- a/src/Form/HmNewsletterNewsletterAdminForm.php
+++ b/src/Form/HmNewsletterNewsletterAdminForm.php
@@ -27,7 +27,14 @@ class HmNewsletterNewsletterAdminForm extends ConfigFormBase {
     $config = $this->config('hm_newsletter.settings');
 
     foreach (Element::children($form['hm_newsletter']) as $variable) {
-      $config->set($variable, $form_state->getValue($form['hm_newsletter'][$variable]['#parents']));
+      if ($variable === 'hm_displayed_agreements') {
+        // Split by "|" and filter empty values.
+        $displayed_agreements = array_filter(explode('|', $form_state->getValue($form['hm_newsletter'][$variable]['#parents'])));
+        $config->set($variable, $displayed_agreements);
+      }
+      else {
+        $config->set($variable, $form_state->getValue($form['hm_newsletter'][$variable]['#parents']));
+      }
     }
     $config->save();
 
@@ -80,6 +87,14 @@ class HmNewsletterNewsletterAdminForm extends ConfigFormBase {
       '#description' => $this->t('Text is displayed in the footer of the newsletter subscription form.'),
       '#type' => 'textarea',
       '#default_value' => $hm_newsletter_settings->get('hm_imprint_text'),
+    );
+
+    $displayed_agreements = implode('|', $hm_newsletter_settings->get('hm_displayed_agreements'));
+    $form['hm_newsletter']['hm_displayed_agreements'] = array(
+      '#title' => $this->t('Displayed agreement names (separated by "|")'),
+      '#description' => $this->t('Agreements are used to filter what is displayed for newsletter.'),
+      '#type' => 'textfield',
+      '#default_value' => $displayed_agreements,
     );
 
     return parent::buildForm($form, $form_state);

--- a/src/Form/HmNewsletterNewsletterAdminForm.php
+++ b/src/Form/HmNewsletterNewsletterAdminForm.php
@@ -89,12 +89,12 @@ class HmNewsletterNewsletterAdminForm extends ConfigFormBase {
       '#default_value' => $hm_newsletter_settings->get('hm_imprint_text'),
     );
 
-    $displayed_agreements = implode('|', $hm_newsletter_settings->get('hm_displayed_agreements'));
+    $displayed_agreements = $hm_newsletter_settings->get('hm_displayed_agreements');
     $form['hm_newsletter']['hm_displayed_agreements'] = array(
       '#title' => $this->t('Displayed agreement names (separated by "|")'),
       '#description' => $this->t('Agreements are used to filter what is displayed for newsletter.'),
       '#type' => 'textfield',
-      '#default_value' => $displayed_agreements,
+      '#default_value' => (empty($displayed_agreements)) ? '' : implode('|', $displayed_agreements),
     );
 
     return parent::buildForm($form, $form_state);

--- a/src/Plugin/Block/HmNewsletterBlock.php
+++ b/src/Plugin/Block/HmNewsletterBlock.php
@@ -81,6 +81,7 @@ class HmNewsletterBlock extends BlockBase implements ContainerFactoryPluginInter
           'hm_newsletter' => array(
             'env' => $settings->get('hm_environment'),
             'clientid' => $settings->get('hm_client_id'),
+            'displayed_agreements' => $settings->get('hm_displayed_agreements'),
           ),
         ),
       ),

--- a/templates/hm-newsletter-form.html.twig
+++ b/templates/hm-newsletter-form.html.twig
@@ -139,16 +139,6 @@
         </div>
         {% endblock %}
 
-        {% block container_privacy %}
-            <div class="hm_newsletter__privacy container-content-item promo_permission_text--hidden container-content-item">
-                <span class="icon icon-close"></span>
-
-                <div class="container-content-dynamic">
-
-                </div>
-            </div>
-        {% endblock %}
-
         {% block container_strings %}
             <script type="application/json" class="hm_newsletter__strings">
                 {


### PR DESCRIPTION
We had following problem. Only `datenschutzeinwilligung` agreement was displayed even when site requires more of them.

So following things are improved/changed:
- now more then one agreement is displayed and it's configurable what agreements are supported
- code for displaying agreements that have hidden text is more generic now
- documentation is updated since it's kinda tricky to figure out what should be filled in Block configuration for `Newsletter` field
- schema is added for configuration

Following things should be tested:
- testing of module update
- testing of 0 agreements, 1 agreements and 2+ agreements
- testing of 0 newsletters, 1 newsletter and 2+ newsletters

